### PR TITLE
Actions: Build workflow

### DIFF
--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -18,4 +18,4 @@ jobs:
 
       - name: Build Image ${{ matrix.php }}-${{ matrix.type }}
         run: |
-            docker build ./php${{ matrix.php }}/${{ matrix.type }}/ -t ${{matrix.php}}-${{matix.type}}
+            docker build ./php${{ matrix.php }}/${{ matrix.type }}/ -t ${{matrix.php}}-${{matrix.type}}

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -1,0 +1,21 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [7.2, 7.3, 7.4]
+        type: [apache, fpm-alpine, fpm]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Image ${{ matrix.php }}-${{ matrix.type }}
+        run: |
+            docker build ./php${{ matrix.php }}/${{ matrix.type }}/ --file Dockerfile

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/dockerpush.yml
+++ b/.github/workflows/dockerpush.yml
@@ -18,4 +18,4 @@ jobs:
 
       - name: Build Image ${{ matrix.php }}-${{ matrix.type }}
         run: |
-            docker build ./php${{ matrix.php }}/${{ matrix.type }}/ --file Dockerfile
+            docker build ./php${{ matrix.php }}/${{ matrix.type }}/ -t ${{matrix.php}}-${{matix.type}}


### PR DESCRIPTION
zum Vergleich:
- Actions sind alle 9 Builds in 3-4 Minuten durch gelaufen.
- Dockercloud in der Zeit noch nicht mal einer gestartet.


würde den hook zu docker hub bestehen lassen für den production build, aber für die Pull-Requests eindeutig auf Actions setzen.

@schuer wenn das hier ok für dich ist, bitte nur approven. :kissing_heart: 

ich würde dann im Anschluss die Settings auf Github und Dockerhub dafür anpassen und es direkt mit diesem PR testen wollen.