### PR TITLE
implement custom setup

### DIFF
--- a/php7.2/apache/docker-entrypoint.sh
+++ b/php7.2/apache/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD

--- a/php7.2/fpm-alpine/docker-entrypoint.sh
+++ b/php7.2/fpm-alpine/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD

--- a/php7.2/fpm/docker-entrypoint.sh
+++ b/php7.2/fpm/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD

--- a/php7.3/apache/docker-entrypoint.sh
+++ b/php7.3/apache/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD

--- a/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD

--- a/php7.3/fpm/docker-entrypoint.sh
+++ b/php7.3/fpm/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD

--- a/php7.4/apache/docker-entrypoint.sh
+++ b/php7.4/apache/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD

--- a/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD

--- a/php7.4/fpm/docker-entrypoint.sh
+++ b/php7.4/fpm/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -70,6 +70,23 @@ else
     echo >&2 "🚀 REDAXO setup successful."
     echo >&2 " "
 
+    # run custom setup (if available)
+    # hint: enables child images to extend the setup process
+    CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";
+    if [[ -x "$CUSTOM_SETUP" ]]; then
+      echo >&2 "👉 Run custom setup..."
+
+      if "$CUSTOM_SETUP"; then
+        echo >&2 " "
+        echo >&2 "🚀 Custom setup successful."
+        echo >&2 " "
+      else
+          echo >&2 " "
+          echo >&2 "❌ Custom setup failed."
+          echo >&2 " "
+          exit 1
+      fi
+    fi
 fi
 
 # execute CMD


### PR DESCRIPTION
enables child images to extend the setup process

@bloep Ich fand den `run-parts`-Weg (wie in https://www.camptocamp.com/de/actualite/flexible-docker-entrypoints-scripts/) zu komplex und habe es runtergebrochen auf ein einzelnes Setup-Script. Das macht es einfacher und sollte für unsere Zwecke ausreichen. Andernfalls könnten wir immer noch erweitern.