### PR TITLE
OPcache: reduce cache time and disable cli

### DIFF
--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -60,14 +60,13 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # enable apache modules

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -49,14 +49,13 @@ RUN set -ex; \
     apk del .build-deps
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -60,14 +60,13 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -61,14 +61,13 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # enable apache modules

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -50,14 +50,13 @@ RUN set -ex; \
     apk del .build-deps
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 

--- a/php7.3/fpm/Dockerfile
+++ b/php7.3/fpm/Dockerfile
@@ -61,14 +61,13 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 

--- a/php7.4/apache/Dockerfile
+++ b/php7.4/apache/Dockerfile
@@ -61,14 +61,13 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # enable apache modules

--- a/php7.4/fpm-alpine/Dockerfile
+++ b/php7.4/fpm-alpine/Dockerfile
@@ -50,14 +50,13 @@ RUN set -ex; \
     apk del .build-deps
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 

--- a/php7.4/fpm/Dockerfile
+++ b/php7.4/fpm/Dockerfile
@@ -61,14 +61,13 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 

--- a/templates/Dockerfile-alpine
+++ b/templates/Dockerfile-alpine
@@ -50,14 +50,13 @@ RUN set -ex; \
     apk del .build-deps
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 %%VARIANT_EXTRAS%%

--- a/templates/Dockerfile-debian
+++ b/templates/Dockerfile-debian
@@ -61,14 +61,13 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 # enable OPcache
-# use recommended settings: https://secure.php.net/manual/en/opcache.installation.php
+# see https://secure.php.net/manual/en/opcache.installation.php
 RUN { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \
-        echo 'opcache.revalidate_freq=60'; \
+        echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 %%VARIANT_EXTRAS%%


### PR DESCRIPTION
Former 60s cache time is not suitable for local development. Also cli shouldn’t be cached.