### PR TITLE
Do not install opcache

### DIFF
--- a/php7.2/apache/Dockerfile
+++ b/php7.2/apache/Dockerfile
@@ -33,7 +33,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -61,7 +60,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/php7.2/fpm-alpine/Dockerfile
+++ b/php7.2/fpm-alpine/Dockerfile
@@ -28,7 +28,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -50,7 +49,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/php7.2/fpm/Dockerfile
+++ b/php7.2/fpm/Dockerfile
@@ -33,7 +33,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -61,7 +60,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -34,7 +34,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -62,7 +61,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -29,7 +29,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -51,7 +50,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/php7.3/fpm/Dockerfile
+++ b/php7.3/fpm/Dockerfile
@@ -34,7 +34,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -62,7 +61,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/php7.4/apache/Dockerfile
+++ b/php7.4/apache/Dockerfile
@@ -34,7 +34,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -62,7 +61,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/php7.4/fpm-alpine/Dockerfile
+++ b/php7.4/fpm-alpine/Dockerfile
@@ -29,7 +29,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -51,7 +50,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/php7.4/fpm/Dockerfile
+++ b/php7.4/fpm/Dockerfile
@@ -34,7 +34,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -62,7 +61,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/templates/Dockerfile-alpine
+++ b/templates/Dockerfile-alpine
@@ -29,7 +29,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -51,7 +50,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \

--- a/templates/Dockerfile-debian
+++ b/templates/Dockerfile-debian
@@ -34,7 +34,6 @@ RUN set -ex; \
     docker-php-ext-install -j "$(nproc)" \
         gd \
         intl \
-        opcache \
         pdo_mysql \
         zip \
     # delete output (except errors)
@@ -62,7 +61,9 @@ RUN set -ex; \
 
 # enable OPcache
 # see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
+RUN set -eux; \
+    docker-php-ext-enable opcache; \
+    { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
         echo 'opcache.max_accelerated_files=4000'; \


### PR DESCRIPTION
Since it’s already pre-built in PHP images

docker-library/wordpress@def14e3
Thx to the docker team!