### PR TITLE
update file owner and group of writable folders (cache, data)

### DIFF
--- a/php7.2/apache/docker-entrypoint.sh
+++ b/php7.2/apache/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php7.2/fpm-alpine/docker-entrypoint.sh
+++ b/php7.2/fpm-alpine/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php7.2/fpm/docker-entrypoint.sh
+++ b/php7.2/fpm/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php7.3/apache/docker-entrypoint.sh
+++ b/php7.3/apache/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php7.3/fpm-alpine/docker-entrypoint.sh
+++ b/php7.3/fpm-alpine/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php7.3/fpm/docker-entrypoint.sh
+++ b/php7.3/fpm/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php7.4/apache/docker-entrypoint.sh
+++ b/php7.4/apache/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php7.4/fpm-alpine/docker-entrypoint.sh
+++ b/php7.4/fpm-alpine/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php7.4/fpm/docker-entrypoint.sh
+++ b/php7.4/fpm/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php8.0-rc/apache/docker-entrypoint.sh
+++ b/php8.0-rc/apache/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php8.0-rc/fpm-alpine/docker-entrypoint.sh
+++ b/php8.0-rc/fpm-alpine/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/php8.0-rc/fpm/docker-entrypoint.sh
+++ b/php8.0-rc/fpm/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -65,6 +65,9 @@ else
         exit 1
     fi
 
+    # update file owner and group of writable folders (cache, data)
+    chown -R www-data:www-data redaxo/cache redaxo/data;
+
     # done!
     echo >&2 " "
     echo >&2 "🚀 REDAXO setup successful."


### PR DESCRIPTION
Nach der Installation von REDAXO haben manche Ordner und Dateien `root:root`, z. B. redaxo/cache/, und sind dadurch u. U. nicht beschreibbar.

Der PR aktualisiert nach der Installation einmal den Cache- und Data-Ordner auf `www-data/www-data`.