### PR TITLE
Imagick: use PECL version again since it works with PHP 8 now

### DIFF
--- a/templates/Dockerfile-debian
+++ b/templates/Dockerfile-debian
@@ -41,9 +41,8 @@ RUN set -ex; \
     ; \
     \
     # install imagick
-    # use github version for now until release from https://pecl.php.net/get/imagick is ready for PHP 8
     mkdir -p /usr/src/php/ext/imagick; \
-    curl -fsSL https://github.com/Imagick/imagick/archive/06116aa24b76edaf6b1693198f79e6c295eda8a9.tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+    curl -fsSL https://pecl.php.net/get/imagick | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
     docker-php-ext-install imagick; \
     \
     # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies


### PR DESCRIPTION
see https://pecl.php.net/package/imagick/3.5.0