### PR TITLE
Revert www-data user + go back to 5.13.0 again

### DIFF
--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php7.3/apache/Dockerfile
+++ b/php7.3/apache/Dockerfile
@@ -109,11 +109,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["apache2-foreground"]

--- a/php7.3/apache/hooks/post_push
+++ b/php7.3/apache/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php7.3-apache 5.13-php7.3-apache 5-php7.3-apache; do
+for tag in 5.13.0-php7.3-apache 5.13-php7.3-apache 5-php7.3-apache; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -62,7 +62,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php7.3/fpm-alpine/Dockerfile
+++ b/php7.3/fpm-alpine/Dockerfile
@@ -76,11 +76,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["php-fpm"]

--- a/php7.3/fpm-alpine/hooks/post_push
+++ b/php7.3/fpm-alpine/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php7.3-fpm-alpine 5.13-php7.3-fpm-alpine 5-php7.3-fpm-alpine; do
+for tag in 5.13.0-php7.3-fpm-alpine 5.13-php7.3-fpm-alpine 5-php7.3-fpm-alpine; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php7.3/fpm/Dockerfile
+++ b/php7.3/fpm/Dockerfile
@@ -107,11 +107,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["php-fpm"]

--- a/php7.3/fpm/Dockerfile
+++ b/php7.3/fpm/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php7.3/fpm/hooks/post_push
+++ b/php7.3/fpm/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php7.3-fpm 5.13-php7.3-fpm 5-php7.3-fpm; do
+for tag in 5.13.0-php7.3-fpm 5.13-php7.3-fpm 5-php7.3-fpm; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php7.4/apache/Dockerfile
+++ b/php7.4/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php7.4/apache/Dockerfile
+++ b/php7.4/apache/Dockerfile
@@ -109,11 +109,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["apache2-foreground"]

--- a/php7.4/apache/hooks/post_push
+++ b/php7.4/apache/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php7.4-apache 5.13.1 5.13-php7.4-apache 5.13 5-php7.4-apache 5; do
+for tag in 5.13.0-php7.4-apache 5.13.0 5.13-php7.4-apache 5.13 5-php7.4-apache 5; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php7.4/fpm-alpine/Dockerfile
+++ b/php7.4/fpm-alpine/Dockerfile
@@ -62,7 +62,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php7.4/fpm-alpine/Dockerfile
+++ b/php7.4/fpm-alpine/Dockerfile
@@ -76,11 +76,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["php-fpm"]

--- a/php7.4/fpm-alpine/hooks/post_push
+++ b/php7.4/fpm-alpine/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php7.4-fpm-alpine 5.13-php7.4-fpm-alpine 5-php7.4-fpm-alpine; do
+for tag in 5.13.0-php7.4-fpm-alpine 5.13-php7.4-fpm-alpine 5-php7.4-fpm-alpine; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php7.4/fpm/Dockerfile
+++ b/php7.4/fpm/Dockerfile
@@ -107,11 +107,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["php-fpm"]

--- a/php7.4/fpm/Dockerfile
+++ b/php7.4/fpm/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php7.4/fpm/hooks/post_push
+++ b/php7.4/fpm/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php7.4-fpm 5.13-php7.4-fpm 5-php7.4-fpm; do
+for tag in 5.13.0-php7.4-fpm 5.13-php7.4-fpm 5-php7.4-fpm; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.0/apache/Dockerfile
+++ b/php8.0/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php8.0/apache/Dockerfile
+++ b/php8.0/apache/Dockerfile
@@ -109,11 +109,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["apache2-foreground"]

--- a/php8.0/apache/hooks/post_push
+++ b/php8.0/apache/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php8.0-apache 5.13-php8.0-apache 5-php8.0-apache; do
+for tag in 5.13.0-php8.0-apache 5.13-php8.0-apache 5-php8.0-apache; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.0/fpm-alpine/Dockerfile
+++ b/php8.0/fpm-alpine/Dockerfile
@@ -62,7 +62,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php8.0/fpm-alpine/Dockerfile
+++ b/php8.0/fpm-alpine/Dockerfile
@@ -76,11 +76,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["php-fpm"]

--- a/php8.0/fpm-alpine/hooks/post_push
+++ b/php8.0/fpm-alpine/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php8.0-fpm-alpine 5.13-php8.0-fpm-alpine 5-php8.0-fpm-alpine; do
+for tag in 5.13.0-php8.0-fpm-alpine 5.13-php8.0-fpm-alpine 5-php8.0-fpm-alpine; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.0/fpm/Dockerfile
+++ b/php8.0/fpm/Dockerfile
@@ -107,11 +107,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["php-fpm"]

--- a/php8.0/fpm/Dockerfile
+++ b/php8.0/fpm/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php8.0/fpm/hooks/post_push
+++ b/php8.0/fpm/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php8.0-fpm 5.13-php8.0-fpm 5-php8.0-fpm; do
+for tag in 5.13.0-php8.0-fpm 5.13-php8.0-fpm 5-php8.0-fpm; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.1-rc/apache/Dockerfile
+++ b/php8.1-rc/apache/Dockerfile
@@ -95,7 +95,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php8.1-rc/apache/Dockerfile
+++ b/php8.1-rc/apache/Dockerfile
@@ -109,11 +109,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["apache2-foreground"]

--- a/php8.1-rc/apache/hooks/post_push
+++ b/php8.1-rc/apache/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php8.1-rc-apache 5.13-php8.1-rc-apache 5-php8.1-rc-apache; do
+for tag in 5.13.0-php8.1-rc-apache 5.13-php8.1-rc-apache 5-php8.1-rc-apache; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.1-rc/fpm-alpine/Dockerfile
+++ b/php8.1-rc/fpm-alpine/Dockerfile
@@ -62,7 +62,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php8.1-rc/fpm-alpine/Dockerfile
+++ b/php8.1-rc/fpm-alpine/Dockerfile
@@ -76,11 +76,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["php-fpm"]

--- a/php8.1-rc/fpm-alpine/hooks/post_push
+++ b/php8.1-rc/fpm-alpine/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php8.1-rc-fpm-alpine 5.13-php8.1-rc-fpm-alpine 5-php8.1-rc-fpm-alpine; do
+for tag in 5.13.0-php8.1-rc-fpm-alpine 5.13-php8.1-rc-fpm-alpine 5-php8.1-rc-fpm-alpine; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.1-rc/fpm/Dockerfile
+++ b/php8.1-rc/fpm/Dockerfile
@@ -107,11 +107,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["php-fpm"]

--- a/php8.1-rc/fpm/Dockerfile
+++ b/php8.1-rc/fpm/Dockerfile
@@ -93,7 +93,7 @@ RUN set -eux; \
 VOLUME /var/www/html
 
 # declare REDAXO version and checksum
-ENV REDAXO_VERSION=5.13.1 REDAXO_SHA=94397abd2b7812735b1e69225bb12d85fac57c39
+ENV REDAXO_VERSION=5.13.0 REDAXO_SHA=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # fetch REDAXO, validate checksum and extract to tmp folder
 RUN set -e; \

--- a/php8.1-rc/fpm/hooks/post_push
+++ b/php8.1-rc/fpm/hooks/post_push
@@ -19,7 +19,7 @@ set -e
 # X
 
 
-for tag in 5.13.1-php8.1-rc-fpm 5.13-php8.1-rc-fpm 5-php8.1-rc-fpm; do
+for tag in 5.13.0-php8.1-rc-fpm 5.13-php8.1-rc-fpm 5-php8.1-rc-fpm; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/templates/Dockerfile-alpine
+++ b/templates/Dockerfile-alpine
@@ -76,11 +76,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["%%CMD%%"]

--- a/templates/Dockerfile-debian
+++ b/templates/Dockerfile-debian
@@ -107,11 +107,5 @@ RUN set -e; \
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# prepare for www-data user and switch
-RUN set -ex; \
-    mkdir -p /var/www/html; \
-    chown -R www-data:www-data /var/www/html
-USER www-data
-
 # run CMD
 CMD ["%%CMD%%"]

--- a/update.sh
+++ b/update.sh
@@ -20,8 +20,8 @@ set -euo pipefail
 # hint: we could curl the latest release from github instead but wouldn't receive the sha1 checksum.
 # That's why we write it down here after we generate it like this:
 # `curl -Ls https://github.com/redaxo/redaxo/releases/download/5.12.1/redaxo_5.12.1.zip | shasum`
-latest=5.13.1
-sha1=94397abd2b7812735b1e69225bb12d85fac57c39
+latest=5.13.0
+sha1=9e72d1c72b369a8476b8499eb1239e87536349a4
 
 # declare PHP versions
 phpVersions=( 8.1-rc 8.0 7.4 7.3 )


### PR DESCRIPTION
War keine gute Idee, den User auf www-data zu wechseln. Hatte nicht drüber nachgedacht, dass das im weiteren Verlauf zu Problemen führen könnte, etwa bei den Demos oder im Projekt REDAXO-mit-Docker.

Besser so beibehalten wir bisher und es den Endnutzern überlassen, am Ende den User und die Permissions sauber einzurichten.