### PR TITLE
Add recipe for apache variant with Xdebug enabled

### DIFF
--- a/recipes/apache-xdebug/README.md
+++ b/recipes/apache-xdebug/README.md
@@ -1,0 +1,5 @@
+# REDAXO + Apache + Xdebug
+
+1. Place `docker-compose.yml` in your project root
+2. Run `docker-compose up -d` to fire up Docker.
+3. Access REDAXO in your browser at [http://localhost](http://localhost)

--- a/recipes/apache-xdebug/docker-compose.yml
+++ b/recipes/apache-xdebug/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3"
+services:
+
+  redaxo:
+    build: ./docker   # build folder for redaxo image
+    ports:
+      - ${REDAXO_PORT:-80}:80   # web server will use port 80 for http as default or port defined by REDAXO_PORT
+    volumes:
+      - ./html:/var/www/html:cached   # sync web root with local folder `html`
+    depends_on:
+      - db   # requires database container to be available
+    environment:
+      REDAXO_SERVER: http://localhost
+      REDAXO_SERVERNAME: My Project
+      REDAXO_ERROR_EMAIL: mail@you.example
+      REDAXO_LANG: de_de
+      REDAXO_TIMEZONE: Europe/London
+      REDAXO_DB_HOST: db   # database container name
+      REDAXO_DB_NAME: redaxo
+      REDAXO_DB_LOGIN: redaxo
+      REDAXO_DB_PASSWORD: redaxo   # better not use for production!
+      REDAXO_DB_CHARSET: utf8mb4
+      REDAXO_ADMIN_USER: admin
+      REDAXO_ADMIN_PASSWORD: admin123   # better not use for production!
+
+  db:
+    image: mysql:8
+    volumes:
+      - ./db:/var/lib/mysql:cached   # sync database with local folder `db`
+    environment:
+      MYSQL_DATABASE: redaxo
+      MYSQL_USER: redaxo
+      MYSQL_PASSWORD: redaxo   # better not use for production!
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'   # better not use for production!

--- a/recipes/apache-xdebug/docker/Dockerfile
+++ b/recipes/apache-xdebug/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM friendsofredaxo/redaxo:5 as base
+
+# Install and activate xdebug from pecl
+RUN set -ex; \
+    pecl -q update-channels; \
+    pecl -q install xdebug; \
+    docker-php-ext-enable xdebug; \
+    { \
+        echo 'xdebug.mode = develop,debug'; \
+        echo 'xdebug.start_with_request = trigger'; \
+        echo 'xdebug.client_host = host.docker.internal'; \
+    } > /usr/local/etc/php/conf.d/90-xdebug.ini; \
+    rm -rf /tmp/pear;
+
+# Remove overhead from previous layers by starting from scratch
+FROM scratch
+COPY --from=base / /
+CMD ["apache2-foreground"]


### PR DESCRIPTION
Add a new recipe with Xdebug extension enabled for remote debugging.

Use this for development purposes only.