### PR TITLE
remove alpine images + hotfix tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,16 @@ There’s no official Docker image for [REDAXO](https://github.com/redaxo/redaxo
 
 Tags follow this scheme: `REDAXO-PHP-Variant`.
 
-* __REDAXO version__ can include major, feature or hotfix releases, such as: `5`, `5.9`, `5.9.0`.
+* __REDAXO version__ can include major or feature releases, such as: `5`, `5.13`.
 * __PHP versions__: `php7.4` _(default)_, `php8.0`, `php8.1`
-* __Variants__: `apache` _(default)_, `fpm`, `fpm-alpine`
+* __Variants__: `apache` _(default)_, `fpm`
 
 As a __shorthand__, you can provide just the REDAXO version to use it with the default PHP version (7.4) and the default variant (Apache).
 
 Examples:
 
-* `5.9.0-php7.4-fpm`
-* `5.9.0-php7.4-fpm-alpine`
-* `5.9.0-php7.4-apache`
-* `5.9-php7.4-apache`
+* `5.13-php7.4-fpm`
+* `5.13-php7.4-apache`
 * `5-php7.4-apache`
 * `5` 🔥
 
@@ -31,15 +29,13 @@ A [complete list of tags](https://hub.docker.com/r/friendsofredaxo/redaxo/tags) 
 
 ## Image variants
 
-We provide 3 image variants:
+We provide two image variants:
 
 * `apache` _(default)_  
   This image comes with an **Apache webserver included** and brings PHP with common extensions required to work with REDAXO out of the box. It is designed to be used both as a throw away container (mount your source code and start the container to start your app), as well as the base to build other images off of.  
   If you are unsure about what your needs are, you probably want to use this one.
 * `fpm`  
   This image doesn’t include a webserver and only starts a PHP FPM container. Use this image if you already have a **separate webserver** running, which is often NGINX.
-* `fpm-alpine`  
-  This image is based on [Alpine Linux](http://alpinelinux.org) and has a **very small footprint**. It doesn’t include a webserver and only starts a PHP FPM process. Use this image if you already have a separate webserver running and a small image size is very important.
 
 
 ## Environment variables

--- a/php7.4/apache/hooks/post_push
+++ b/php7.4/apache/hooks/post_push
@@ -8,18 +8,16 @@ set -e
 
 # We provide these individual tags:
 
-# X.X.X-phpX.X-apache
 # X.X  -phpX.X-apache
 # X    -phpX.X-apache
 
 # We also provide general tags based on the default PHP version and the default variant:
 
-# X.X.X
 # X.X
 # X
 
 
-for tag in 5.13.3-php7.4-apache 5.13.3 5.13-php7.4-apache 5.13 5-php7.4-apache 5; do
+for tag in 5.13-php7.4-apache 5.13 5-php7.4-apache 5; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php7.4/fpm/hooks/post_push
+++ b/php7.4/fpm/hooks/post_push
@@ -8,18 +8,16 @@ set -e
 
 # We provide these individual tags:
 
-# X.X.X-phpX.X-apache
 # X.X  -phpX.X-apache
 # X    -phpX.X-apache
 
 # We also provide general tags based on the default PHP version and the default variant:
 
-# X.X.X
 # X.X
 # X
 
 
-for tag in 5.13.3-php7.4-fpm 5.13-php7.4-fpm 5-php7.4-fpm; do
+for tag in 5.13-php7.4-fpm 5-php7.4-fpm; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.0/apache/hooks/post_push
+++ b/php8.0/apache/hooks/post_push
@@ -8,18 +8,16 @@ set -e
 
 # We provide these individual tags:
 
-# X.X.X-phpX.X-apache
 # X.X  -phpX.X-apache
 # X    -phpX.X-apache
 
 # We also provide general tags based on the default PHP version and the default variant:
 
-# X.X.X
 # X.X
 # X
 
 
-for tag in 5.13.3-php8.0-apache 5.13-php8.0-apache 5-php8.0-apache; do
+for tag in 5.13-php8.0-apache 5-php8.0-apache; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.0/fpm/hooks/post_push
+++ b/php8.0/fpm/hooks/post_push
@@ -8,18 +8,16 @@ set -e
 
 # We provide these individual tags:
 
-# X.X.X-phpX.X-apache
 # X.X  -phpX.X-apache
 # X    -phpX.X-apache
 
 # We also provide general tags based on the default PHP version and the default variant:
 
-# X.X.X
 # X.X
 # X
 
 
-for tag in 5.13.3-php8.0-fpm 5.13-php8.0-fpm 5-php8.0-fpm; do
+for tag in 5.13-php8.0-fpm 5-php8.0-fpm; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.1/apache/hooks/post_push
+++ b/php8.1/apache/hooks/post_push
@@ -8,18 +8,16 @@ set -e
 
 # We provide these individual tags:
 
-# X.X.X-phpX.X-apache
 # X.X  -phpX.X-apache
 # X    -phpX.X-apache
 
 # We also provide general tags based on the default PHP version and the default variant:
 
-# X.X.X
 # X.X
 # X
 
 
-for tag in 5.13.3-php8.1-apache 5.13-php8.1-apache 5-php8.1-apache; do
+for tag in 5.13-php8.1-apache 5-php8.1-apache; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/php8.1/fpm/hooks/post_push
+++ b/php8.1/fpm/hooks/post_push
@@ -8,18 +8,16 @@ set -e
 
 # We provide these individual tags:
 
-# X.X.X-phpX.X-apache
 # X.X  -phpX.X-apache
 # X    -phpX.X-apache
 
 # We also provide general tags based on the default PHP version and the default variant:
 
-# X.X.X
 # X.X
 # X
 
 
-for tag in 5.13.3-php8.1-fpm 5.13-php8.1-fpm 5-php8.1-fpm; do
+for tag in 5.13-php8.1-fpm 5-php8.1-fpm; do
 
     docker tag $IMAGE_NAME $DOCKER_REPO:$tag
     docker push $DOCKER_REPO:$tag

--- a/templates/post_push.sh
+++ b/templates/post_push.sh
@@ -8,13 +8,11 @@ set -e
 
 # We provide these individual tags:
 
-# X.X.X-phpX.X-apache
 # X.X  -phpX.X-apache
 # X    -phpX.X-apache
 
 # We also provide general tags based on the default PHP version and the default variant:
 
-# X.X.X
 # X.X
 # X
 

--- a/update.sh
+++ b/update.sh
@@ -28,19 +28,17 @@ phpVersions=( 8.1 8.0 7.4 )
 defaultPhpVersion='7.4'
 
 # declare image variants (like: apache, fpm, fpm-alpine)
-variants=( apache fpm fpm-alpine )
+variants=( apache fpm )
 defaultVariant='apache'
 
 # declare commands and image bases for given variants
 declare -A cmds=(
     [apache]='apache2-foreground'
     [fpm]='php-fpm'
-    [fpm-alpine]='php-fpm'
 )
 declare -A bases=(
     [apache]='debian'
     [fpm]='debian'
-    [fpm-alpine]='alpine'
 )
 declare -A variantExtras=(
 	[apache]="$(< templates/apache-extras)"
@@ -56,7 +54,9 @@ getVersionTree () {
     if [[ $1 =~ ^(0|[1-9][0-9]*)(\\.(0|[1-9][0-9]*))?(\\.(0|[1-9][0-9]*))?$ ]]; then
         version=$1
         for (( i=1; i<=3; i++ )); do
-            versionTree+=($version)
+            if [ $i -gt 1 ]; then
+              versionTree+=($version)
+            fi
             version="${version%\.*}"
         done
         echo $versionTree


### PR DESCRIPTION
fixes #49

- remove alpine images
- stop using hotfix tags (like `5.13.3`) but use only feature and major tags (`5.13`, `5`)