### PR TITLE
Support installing of addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Admin user to be created:
 * **`REDAXO_ADMIN_USER`**
 * **`REDAXO_ADMIN_PASSWORD`**: must comply with the password policy (requires at least 8 chars)
 
+Installing addons
+
+* **`REDAXO_ADDONS`**: A whitespace separated list of addons to install
+
+To install addons from redaxo.org, use `addon-name`|`version`. To install addons from a URL, use `addon-name`|`url`.
+
 (See examples for `docker run` and `docker-compose` below)
 
 
@@ -76,6 +82,7 @@ $ docker run \
     -e REDAXO_DB_CHARSET='utf8mb4' \
     -e REDAXO_ADMIN_USER='admin' \
     -e REDAXO_ADMIN_PASSWORD='PunKisNOT!dead' \
+    -e REDAXO_ADDONS='adminer|1.9.0 rewrite_url|0.9.4' \
     friendsofredaxo/redaxo:5
 ```
 

--- a/source/docker-entrypoint.sh
+++ b/source/docker-entrypoint.sh
@@ -72,6 +72,28 @@ else
   echo >&2 "🚀 REDAXO setup successful."
   echo >&2 " "
 
+  # install addons (if specified)
+  if [[ -n ${REDAXO_ADDONS} ]] ; then
+      echo >&2 "👉 Installing addons..."
+      IFS=' ' read -r -a addons <<< "${REDAXO_ADDONS}"
+
+      for addon in "${addons[@]}"
+      do
+          echo >&2 "👉 Installing addon ${addon}..."
+          IFS='|' read -r -a addoninfo <<< "${addon}"
+          if echo "${addoninfo[1]}" | grep "^http" &> /dev/null; then
+              curl -s -L "${addoninfo[1]}" -o /tmp/tmp.zip
+              cd redaxo/src/addons &>/dev/null
+              unzip /tmp/tmp.zip &>/dev/null
+              mv ${addoninfo[0]}* "${addoninfo[0]}"
+              cd - &>/dev/null
+          else
+              php redaxo/bin/console install:download "${addoninfo[0]}" "${addoninfo[1]}"
+          fi
+          php redaxo/bin/console package:install "${addoninfo[0]}"
+      done
+  fi
+
   # run custom setup (if available)
   # hint: enables child images to extend the setup process
   CUSTOM_SETUP="/usr/local/bin/custom-setup.sh";


### PR DESCRIPTION
This adds a feature to the entrypoint script that installs Redaxo addons either from redaxo.org or URLs to zip files.