### PR TITLE
bump stable image to PHP 8.3

### DIFF
--- a/images/5-stable/Dockerfile
+++ b/images/5-stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-apache
+FROM php:8.3-apache
 
 # install persistent PHP extensions (they won’t get purged afterwards)
 RUN set -eux; \

--- a/source/images.yml
+++ b/source/images.yml
@@ -14,7 +14,7 @@ images:
       - "5"
     package-url: "https://github.com/redaxo/redaxo/releases/download/5.18.1/redaxo_5.18.1.zip"
     package-sha: "4f7c006cd7a63e2dbb8a12cb8477d6ed137d9f1f"
-    php-version: "8.2"
+    php-version: "8.3"
   - name: "5-edge"
     tags:
       - "5-edge"


### PR DESCRIPTION
Because PHP 8.2 has no more active support, see https://www.php.net/supported-versions.php