### PR TITLE
PHP 8.5 compat: Imagick and OPcache

### DIFF
--- a/images/5-edge/Dockerfile
+++ b/images/5-edge/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex; \
   # https://pecl.php.net/package/imagick
   # fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
   mkdir -p /usr/src/php/ext/imagick; \
-  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.tag.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
   docker-php-ext-install imagick; \
   # pecl install imagick-3.8.0; \
   #   docker-php-ext-enable imagick; \

--- a/images/5-edge/Dockerfile
+++ b/images/5-edge/Dockerfile
@@ -90,10 +90,9 @@ RUN set -ex; \
 # install composer
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-# enable OPcache
+# enable OPcache (PHP < 8.5) and use recommended settings
 # see https://secure.php.net/manual/en/opcache.installation.php
 RUN set -eux; \
-  docker-php-ext-enable opcache; \
   { \
     echo 'opcache.memory_consumption=128'; \
     echo 'opcache.interned_strings_buffer=8'; \

--- a/images/5-edge/Dockerfile
+++ b/images/5-edge/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex; \
   # https://pecl.php.net/package/imagick
   # fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
   mkdir -p /usr/src/php/ext/imagick; \
-  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.zip | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.tag.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
   docker-php-ext-install imagick; \
   # pecl install imagick-3.8.0; \
   #   docker-php-ext-enable imagick; \

--- a/images/5-edge/Dockerfile
+++ b/images/5-edge/Dockerfile
@@ -64,9 +64,13 @@ RUN set -ex; \
   ; \
   # install imagick
   # https://pecl.php.net/package/imagick
-  pecl install imagick-3.8.0; \
-    docker-php-ext-enable imagick; \
-    rm -r /tmp/pear; \
+  # fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
+  mkdir -p /usr/src/php/ext/imagick; \
+  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.zip | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+  docker-php-ext-install imagick; \
+  # pecl install imagick-3.8.0; \
+  #   docker-php-ext-enable imagick; \
+  #   rm -r /tmp/pear; \
   \
   # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
   # see https://github.com/docker-library/wordpress/blob/master/Dockerfile.template

--- a/images/5-stable/Dockerfile
+++ b/images/5-stable/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex; \
   # https://pecl.php.net/package/imagick
   # fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
   mkdir -p /usr/src/php/ext/imagick; \
-  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.tag.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
   docker-php-ext-install imagick; \
   # pecl install imagick-3.8.0; \
   #   docker-php-ext-enable imagick; \

--- a/images/5-stable/Dockerfile
+++ b/images/5-stable/Dockerfile
@@ -90,10 +90,12 @@ RUN set -ex; \
 # install composer
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-# enable OPcache
+# enable OPcache (PHP < 8.5) and use recommended settings
 # see https://secure.php.net/manual/en/opcache.installation.php
 RUN set -eux; \
+  # enable opcache >>>
   docker-php-ext-enable opcache; \
+  # <<< enable opcache
   { \
     echo 'opcache.memory_consumption=128'; \
     echo 'opcache.interned_strings_buffer=8'; \

--- a/images/5-stable/Dockerfile
+++ b/images/5-stable/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex; \
   # https://pecl.php.net/package/imagick
   # fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
   mkdir -p /usr/src/php/ext/imagick; \
-  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.zip | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.tag.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
   docker-php-ext-install imagick; \
   # pecl install imagick-3.8.0; \
   #   docker-php-ext-enable imagick; \

--- a/images/5-stable/Dockerfile
+++ b/images/5-stable/Dockerfile
@@ -64,9 +64,13 @@ RUN set -ex; \
   ; \
   # install imagick
   # https://pecl.php.net/package/imagick
-  pecl install imagick-3.8.0; \
-    docker-php-ext-enable imagick; \
-    rm -r /tmp/pear; \
+  # fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
+  mkdir -p /usr/src/php/ext/imagick; \
+  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.zip | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+  docker-php-ext-install imagick; \
+  # pecl install imagick-3.8.0; \
+  #   docker-php-ext-enable imagick; \
+  #   rm -r /tmp/pear; \
   \
   # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
   # see https://github.com/docker-library/wordpress/blob/master/Dockerfile.template

--- a/scripts/generate-image-files.ts
+++ b/scripts/generate-image-files.ts
@@ -50,7 +50,7 @@ for (const image of images) {
     currentDockerfileSource = currentDockerfileSource.replaceAll(key, replacements[key]);
   });
 
-  // Remove OPcache support in PHP 8.5, because it is enabled by default
+  // Remove to enable OPcache in PHP 8.5, because it is already enabled by default
   if (['8.5', '8.5-rc'].some(el => String(image["php-version"]).includes(el))) {
     currentDockerfileSource = currentDockerfileSource.replaceAll(/(^\s*)(# enable opcache >>>)([\s\S]*?)(# <<< enable opcache)(\r?\n)/gm, '');
   }

--- a/scripts/generate-image-files.ts
+++ b/scripts/generate-image-files.ts
@@ -50,6 +50,11 @@ for (const image of images) {
     currentDockerfileSource = currentDockerfileSource.replaceAll(key, replacements[key]);
   });
 
+  // Remove OPcache support in PHP 8.5, because it is enabled by default
+  if (['8.5', '8.5-rc'].some(el => String(image["php-version"]).includes(el))) {
+    currentDockerfileSource = currentDockerfileSource.replaceAll(/(^\s*)(# enable opcache >>>)([\s\S]*?)(# <<< enable opcache)(\r?\n)/gm, '');
+  }
+
   Deno.writeTextFileSync(`${targetDir}/Dockerfile`, currentDockerfileSource);
 
   /**

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex; \
   # https://pecl.php.net/package/imagick
   # fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
   mkdir -p /usr/src/php/ext/imagick; \
-  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.tag.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.tar.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
   docker-php-ext-install imagick; \
   # pecl install imagick-3.8.0; \
   #   docker-php-ext-enable imagick; \

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -90,10 +90,12 @@ RUN set -ex; \
 # install composer
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-# enable OPcache
+# enable OPcache (PHP < 8.5) and use recommended settings
 # see https://secure.php.net/manual/en/opcache.installation.php
 RUN set -eux; \
+  # enable opcache >>>
   docker-php-ext-enable opcache; \
+  # <<< enable opcache
   { \
     echo 'opcache.memory_consumption=128'; \
     echo 'opcache.interned_strings_buffer=8'; \

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex; \
   # https://pecl.php.net/package/imagick
   # fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
   mkdir -p /usr/src/php/ext/imagick; \
-  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.zip | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.tag.gz | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
   docker-php-ext-install imagick; \
   # pecl install imagick-3.8.0; \
   #   docker-php-ext-enable imagick; \

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -64,9 +64,13 @@ RUN set -ex; \
   ; \
   # install imagick
   # https://pecl.php.net/package/imagick
-  pecl install imagick-3.8.0; \
-    docker-php-ext-enable imagick; \
-    rm -r /tmp/pear; \
+  # fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
+  mkdir -p /usr/src/php/ext/imagick; \
+  curl -fsSL https://github.com/Imagick/imagick/archive/45adfb7b1e322eaa6174e88f7d5e27ef20e0596e.zip | tar xvz -C "/usr/src/php/ext/imagick" --strip 1; \
+  docker-php-ext-install imagick; \
+  # pecl install imagick-3.8.0; \
+  #   docker-php-ext-enable imagick; \
+  #   rm -r /tmp/pear; \
   \
   # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
   # see https://github.com/docker-library/wordpress/blob/master/Dockerfile.template


### PR DESCRIPTION
*  Imagick: fetch from GitHub repository until a new PECL version with PHP 8.5 support is available
https://github.com/Imagick/imagick/issues/746
* OPcache: remove to enable in PHP 8.5, because it is already enabled by default
https://wiki.php.net/rfc/make_opcache_required